### PR TITLE
fix: Add Compability for JDK 11

### DIFF
--- a/vss-processor-plugin/build.gradle.kts
+++ b/vss-processor-plugin/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.eclipse.velocitas.vssprocessor.plugin.version.SemanticVersion
 import org.eclipse.velocitas.vssprocessor.plugin.version.VERSION_FILE_DEFAULT_NAME
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
@@ -42,6 +43,17 @@ val versionPath = "$rootDir/../$VERSION_FILE_DEFAULT_NAME"
 val semanticVersion = SemanticVersion(versionPath)
 version = semanticVersion.versionName
 group = "org.eclipse.velocitas"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
+    }
+}
 
 gradlePlugin {
     website.set("https://github.com/eclipse-velocitas/vehicle-app-java-sdk")


### PR DESCRIPTION
This issue is a bit harder to reproduce locally. The following steps are necessary:

1. Setup `jenv` for easy switching to different jdk versions
2. Install `openjdk17` and `openjdk21` 
3. Register `openjdk17` and `openjdk21` using `jenv add ...`
4. open a terminal and switch to the project folder
5. use `jenv local 21` to use jdk21 for building the project
6. execute `./gradlew clean build` (the vss-processor-plugin here is now only supporting >= jdk 21 without the fix being applied; if build with jdk 17 it would be only supporting >= jdk 17)
7. publish the artifact to mavenLocal (a few lines of code need to be adapted in code)
8. change the samples to use the mavenLocal version and add mavenLocal to the plugin repositories
9. execute `jenv local 17` to switch to jdk17 for building the project
10. execute `./gradlew clean build`

Depending on if the fix was applied or not, an error message will be shown. 